### PR TITLE
Use ClassLoader from current thread

### DIFF
--- a/modules/core/kotlin/com/huskerdev/grapl/core/platform/Platform.kt
+++ b/modules/core/kotlin/com/huskerdev/grapl/core/platform/Platform.kt
@@ -53,7 +53,8 @@ abstract class Platform {
             val tmpFile = File(System.getProperty("java.io.tmpdir"), fileName)
             try {
                 FileOutputStream(tmpFile).use {
-                    ClassLoader.getSystemResource(path).openStream().copyTo(it)
+                    val classLoader = Thread.currentThread().contextClassLoader ?: ClassLoader.getSystemClassLoader()
+                    classLoader.getResourceAsStream(path)?.copyTo(it)
                 }
             }catch (e: Exception){
                 throw Exception("Can not read resource library: $path", e)


### PR DESCRIPTION
Use the ClassLoader of the current thread. This fixes issues when the jar is included in another jar. (e.g. a spring boot fat jar)